### PR TITLE
changed "parallel to" to "parallel in" for clarity.

### DIFF
--- a/mailings/program_committee/call_for_submissions.rst
+++ b/mailings/program_committee/call_for_submissions.rst
@@ -18,7 +18,7 @@ online[1].
 Themes
 ------
 
-Two specialized tracks run in parallel to general conference:
+Two specialized tracks run in parallel in general conference:
 
 - Machine learning
 - Reproducible science


### PR DESCRIPTION
fixes confusing wording about symposia running in parallel (noticed by leah, jonathan, anthony, etc.)
