### PR TITLE
ENH: update the call-for-papers for 2019

### DIFF
--- a/manual/mailings/call_for_papers.rst
+++ b/manual/mailings/call_for_papers.rst
@@ -1,37 +1,28 @@
 Call for Papers
 ===============
 
-Congratulations on having your abstract accepted for this year's event -- we 
-look forward to seeing your poster or presentation! As in the past, SciPy2018 
-will release a conference proceedings prior to the start of the conference, 
-and you are invited to contribute a full-length paper (up to 8 pages) expanding 
-on your abstract.
+Congratulations on having your abstract accepted for this year's event -- we look forward to seeing your poster or presentation! As in the past, SciPy2019 will release a conference proceedings prior to the start of the conference, and you are invited to contribute a full-length paper (up to 8 pages) expanding on your abstract.
 
-The proceedings are aimed at highlighting significant contributions to 
-scientific computing in Python, such as:
+The proceedings are aimed at highlighting significant contributions to scientific computing in Python, such as:
 
-- new software packages that support the Scientific Python Stack
-- domain-specific applications of Python in any field of research
-- significant improvements to existing software packages
-- hardware systems designed to support the Python stack
-- applications of scientific computing in education
+    - new software packages that support the Scientific Python Stack
+    - domain-specific applications of Python in any field of research
+    - significant improvements to existing software packages
+    - hardware systems designed to support the Python stack
+    - applications of scientific computing in education
+    - sustaining communities around scientific Python libraries
 
-Papers must be submitted as pull requests by May 14th.  At that point, the 
-six-week open review period will begin.  During this time, members from the 
-program committee and the scientific Python community at large will provide 
-feedback, which should be addressed through discussion on GitHub and by 
-updating the pull request.
+Papers must be submitted as pull requests by May 21st. At that point, the five-week open review period will begin. During this time, members from the program committee and the scientific Python community at large will provide feedback, which should be addressed through discussion on GitHub and by updating the pull request.
 
-When submitting a paper to the proceedings, you may be contacted by the
-Proceedings Chairs to assist in reviewing at least one paper.
+When submitting a paper to the proceedings, you may be contacted by the Proceedings Chairs to assist in reviewing at least one paper.
 
 Further instructions can be found here:
 
 https://github.com/scipy-conference/scipy_proceedings
 
-Sincerely, the SciPy 2018 Proceedings Chairs,
+Sincerely, the SciPy 2019 Proceedings Chairs,
 
-- David Lippa <dalippa@gmail.com>
-- M Pacer <mpacer@berkeley.edu>
-- Dillon Niederhut <dniederhut@enthought.com>
-- Fatih Akici <akicifatih@gmail.com>
+    Chris Calloway <cbc@unc.edu>
+    David Lippa <dalippa@gmail.com>
+    Dillon Niederhut <dillon.niederhut@gmail.com>
+    David Shupe <dave.shupe@gmail.com>


### PR DESCRIPTION
Changes the years, necessary dates, and committee co-
chair names and emails.