### PR TITLE
Notes from SciPy 2018, 2019 Post-con lunch

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -18,6 +18,7 @@ Contents
    manual/sponsored_attendance
    manual/mailings/index
    manual/random
+   yearly-notes/index
 
 Search
 ======

--- a/yearly-notes/2018/2018-post-con-lunch.rst
+++ b/yearly-notes/2018/2018-post-con-lunch.rst
@@ -1,0 +1,171 @@
+Notes From the SciPy 2018 Post-Con Lunch
+========================================
+
+Notes from the post-con lunch at the end of SciPy 2018. Notes taken by
+Alexandre Chabot-Leclerc.
+
+Grab bag
+--------
+
+- Have an "unconference room" + hallway track.
+- What about an official mentoring or pair programming room/session? Office
+  hours? For people new to Python, or who just need some help. Maybe ask for
+  experienced members of the community to volunteer a few hours during the week
+  to "staff" the help room. It's some kind of Help Desk++.
+
+
+Sprints
+-------
+
+- Good to have an actual organization
+- Master spreadsheet was good because it forced sprint leaders to fill out
+  certain details
+- They should be better advertised. Do more work with Communications
+- Don't like the word "sprints" (also echoed during the SciPy 2019 BOF). Need
+  a more inclusive name.
+- What about a sprint for newcomers to get started? Maybe to work on their own
+  stuff with experienced members of the community. See also the idea of
+  a mentoring program discussed below under Activities.
+- Sprint financial aid didn't work well. Not really needed this year. Maybe
+  keep it as an option?
+
+
+Tutorials
+---------
+
+- The bar for acceptance is very high. Some proposals are much more fleshed out
+  than others. How to make it inclusive and "easy" to get started, without
+  requiring all the materials up front?
+- Tutorials mentorships for more varied applicants?
+- Git reviews?
+- Add link to good past submissions in the submission form.
+- Explicitly prompt for timing information in submission form.
+- Reach out to more events (with comms), e.g. PyLadies, Meetups, etc.
+- Not enough reviews. Co-chairs reviewed all 55 submissions. Each reviewers did
+  5-6 reviews.
+- Prompting for submissions from past attendees and from particular
+  organizations/projects/languages worked great.
+- Too many attendees. The rooms were really crowed. How to control? Check
+  badges? Silly hats? Colored lanyards?
+- Could we live stream popular tutorials into another room?
+
+
+Program Committee
+-----------------
+
+- Repeat of tutorials: The bar for acceptance is very high. Some proposals are
+  much more fleshed out than others. How to make it inclusive and "easy" to get
+  started, without requiring all the materials up front?
+- More submissions than last year.
+- Stickers + prodding works to get reviews done on time
+- Reduce the number of tracks (see alternating years idea below)
+- Pains with EasyChair (but with ETouches too)
+- We received "token submissions" (very weak) from VIPs. We should manage
+  expectations. The submissions should good from everyone. There could be some
+  guidance in the prompt.
+- Similarly for reviews; they should have some substance.
+- The general track turned out to be less popular than other tracks
+- What about tagging talks instead of tracks?
+- What about having single-talk tracks? It basically guarantees a track under
+  a given name if there's a least one talk.
+- Some tracks would need more slots so that there's a critical mass of content
+  for people who would normally not come to SciPy (e.g. some geoscience
+  people). Pair with tutorials for that particular track? Maybe alternate years
+  for certain tracks so there's more space for them? Alternate between US and
+  EU? The downside is that we might attract more people from a given field, but
+  not from new fields.
+- What about entirely open process (public), e.g., Github? Not just double
+  open? There are concerns for GDPR.
+
+
+"Movement" & Logistics
+----------------------
+
+- Rooms were far from each other, which negatively affected the "hallway
+  track". Could we use the 100 floor?
+- The poster sessions conflicts with the job fair. Turn the poster session into
+  more of an event? Drinks? Even more posters?
+
+
+Proceedings
+-----------
+
+- 4 people is good
+- Build server is great
+- Starting early was good
+- Not enough reviewers, some people didn't do their reviews
+- Could abstract reviewers also be paper reviewers? Probably a big ask.
+- At prestigious computer conferences, there's a technical committee who takes
+  care of all the reviews. They're invited. It's a prestigious position. Maybe
+  try something similar? Put the members' names on the website? There's
+  a concern that it may affect the path from contributor to be involved in the
+  proceedings committee. Maybe give different titles to people on the
+  committee? Editors, Committee Chairs, etc.
+- Get more people involved in the development [of the toolchain?].
+
+
+Financial Aid
+-------------
+
+- Eric hand-built a submission reviewing system (he doesn't recommend doing
+  that)
+- The expanded submission form was very valuable, but it was also more
+  intimidating. It seems like a zero-sum game: too many boxes lead to fewer
+  applicants.
+- Focus on financial aid as a way of brining in new people (?) in addition to
+  bringing in members of the community who would otherwise not be able to
+  attend.
+- How to get more money?
+- How to manage financial aid for speakers? Should they get it automatically or
+  not? Should the funds be separate? Timing with the talk acceptance is also
+  tricky.
+
+
+Activities
+----------
+
+- 80 people signed up for Broken Spoke, 55 on bus + others with other means of
+  transportation
+- General organization started too late
+- Vislab was super popular
+- More planning of some mentoring program. Ideas were: early career mentoring,
+  new-to-python mentoring, and new-to-SciPy mentoring.
+- Clarify with committee members about the implications of being on the
+  activities committee (tasks, deadlines, number of people, etc.)
+
+
+Sponsors
+--------
+
+- Send sponsorship packages earlier in the year because of the timing with
+  which some companies set their budgets.
+- Offer doing interview with possible candidates during SciPy to gold sponsors
+
+
+Diversity
+---------
+
+- Meetups were good
+- BoFs were great
+- Do more, earlier communications
+- Good discussions happened on Slack and during talks
+- Some people didn't actually help even thought they said they would. How to
+  get more dedicated committee members?
+- Offer diversity scholarships?
+- Schedule diversity BoFs in large room after big talk, so they have more
+  exposure, and more would likely attend.
+
+
+Communications
+--------------
+
+- Reach out to more underrepresented communities
+- The spreadsheet was really useful
+- Do more thorough follow up
+
+
+About the physical program
+--------------------------
+
+- Don't use two different sections about financial aid. Maybe differentiate
+  them with footnotes?

--- a/yearly-notes/2018/index.rst
+++ b/yearly-notes/2018/index.rst
@@ -1,0 +1,6 @@
+Notes from SciPy 2018
+=====================
+
+.. toctree::
+
+  2018-post-con-lunch

--- a/yearly-notes/2019/2019-post-con-lunch.rst
+++ b/yearly-notes/2019/2019-post-con-lunch.rst
@@ -1,0 +1,207 @@
+Notes From the SciPy 2019 Post-Con Lunch
+========================================
+
+Notes from the post-con lunch that happened on July 12, 2019. Notes taken by Alexandre Chabot-Leclerc.
+
+To Grow / Not Grow?
+-------------------
+
+- Maybe we do not grow, and let other conferences emerge?
+- Maybe stream popular talks/tutorials from one room to the other?
+- Don't market the event too much because it's full already.
+- Maybe alternate years? East/West Coast?
+- Use more floors in the AT&T Center? But that makes it hard to walk around.
+- Invite/Organize a co-conferences in the same venue?
+- Have a data science/machine learning track in a different room? That would
+  probably mean that some tracks will be more competitive than others
+
+General
+-------
+
+- Each year, only invite current organizers to the Organizer Slack
+- Maybe assign floater cochair to help commities who lose cochairs?
+- Schedule a hangout about EasyChair with Gil (or whoever has most knowledge)
+  about how to do different things during the 2020 kickoff meeting
+- Give Admin access EasyChair to at leaset one tutorial co-chair so they can
+  send reviews to the authors.
+- We need more incentives for reviewers. Every committee could use more
+  reviewers
+- Tools plannary is great
+- collect an estimated attendance numbers for talks
+- Print signs saying "please be mindful when to enter the room I would talk is
+  happening"
+- Add descriptions of mini symposia to the program, and next to the rooms
+
+Code Of Conduct
+```````````````
+
+- Remind people that Slack is covered by the Code of Conduct
+- Ask people to send feedback about the tutorials to the chairs to prevent
+  awkward and innapropriate feedback from attendees.
+
+  - Explicitly cover this issue in the code of conduct
+
+- For Code of Conduct violation, have trained volunteers with bright orange
+  shirts to whom people can report violations (inspire by what PyCon does)
+- Provided a phone number and email address where violations can be reported
+- To have one CoC volunteer per room
+
+Activities
+----------
+
+- The committee could use a third remember
+- The Pinballz staff was helpful
+- Mentorship program
+
+  - Asked about mentors and mentees in the sign-up form
+  - There were 45 mentees and 115 mentors
+  - The committee manually matched people. They needed a lots of web searches
+    because most people didn't list their interests/expertises in the form.
+
+Communications
+--------------
+
+- Having a second person would be better
+- The role should be better defined
+- Ask the keynote presenters for, at least, their title slide so it can be used
+  to tweet about them.
+
+Tutorials
+---------
+
+- Why were there so many tutorials on one topic?
+- There was a lack of communication between cochairs?
+- Extends the definition of core package?
+- Being mindful of people who are trying to sell their stuff
+- Maybe give a consequence to people selling their stuff. Maybe block them for
+  the next year?
+- Our 28 tutorials good or not?
+- There were some no-shows on for some sold-out tutorials. Try to allow people
+  to cancel so we don't hold a spot for no-shows.
+- We need more reviewers. That would reduce noise in reviews.
+- Be clear to reviewer is that the reviews will be shared with the authors.
+  It's a double Open process.
+- Schedule a "review count check" a few days before the end of the review
+  period to make sure all tutorials have enough reviews.
+- Share good review examples for next year.
+- This year we shared goods submissions examples, with permissions from the
+  author, and it was very well received. Do through this year's list and
+  consider asking more authors to sahre their proposal.
+- When creating the program, maybe give less attention to numbers or at least
+  include review her confidence. This requires a strong editorial process,
+  which is not bias-free though.
+- Sanitize reviews before sending back to authors.
+- Email all tutorial attendees that all feedback and feedback should go to
+  through tutorial chairs. Ask for feedback from presenters. Direct messages
+  are weird.
+
+
+Sprints
+-------
+
+- The committee tried _not_ doing the "How to contribute" tutorial in the
+  morning of the Sprints, instead of doing it on Friday as a BoF during lunch. 
+- They sent the materials ahead of time.
+- The Sprints could use more visibility. Many attendees didn't know they
+  exists. Maybe put the sprints in the official conference schedule, make it
+  more obvious on the website somehow.
+
+
+Financial Aid
+-------------
+
+- Targeting financial for the sprints didn't work so well. We wanted to get the
+  key core developers to  attend  the sprints but no one was interested. People
+  who want to come will come anyway. It seems that many of those core
+  maintainers are not grad students anymore and can afford coming anyway. Or
+  maybe people don't apply because they don't know ahead of time what's going
+  to happened.
+- The quality of the submissions was way up.
+- Having a good scoring helped to find backups when someone withdrew their
+  request for financial aid.
+- Thanks a lot to sponsors! Your help is amazing!
+
+
+Program
+-------
+
+- The program committee needs at least a third cochair
+- The program committee really needs three _active_ members.
+- Encourage people to submit talks to Tracks and Symposia instead of General
+- We need a definitive way to move talks from one track to another
+- Should we limit to one talk per person? Maybe restrict on 1st author?
+- Could track chairs review submissions for things that would fit in their
+  track or does not fit in their track?
+- Add a checkbox on the sign-up form saying "are you willing to review?" to
+  gather more reviewers.
+- Be cognizant of junior reviewing seniors. Suggest being neutral in the public
+  comment, and to put the more serious feedback on the section read only by the
+  chairs.
+- Formally disallow time changes to the schedule. It's too hard to manage.
+- What is the place of established packages when submitting talks? We need to
+  make it claer that seniority is not enough. Talks should be judged on the
+  quality of the proposal.
+
+Posters
+-------
+
+- 50 posters this year
+- Formally request that posters are submitted to proceedings.
+- We'd like to increase the prominence of posters:
+
+  - Maybe give the chance of a lightning talk too poster presenters? So we can
+    increase engagements.
+  - Create a best poster award?
+  - Put the posters "in the way to somewhere" so people are forced to interact
+    with them
+  - Organize the poster session where the reception is.
+
+Proceedings
+-----------
+
+- The proceedings were released one week before the conference!!
+- We've issued to DOI's for everything published since 2015!!
+- We're trying to publish slides and posters for SciPy 2019.
+- There's been an 80% attrition rate for paper reviewers. How to prevent this?
+  Provide more incentives? Maybe guarantee a spot of the conference?
+- Set up a RST linter on GitHub to simplify submission process. Or maybe change
+  to a different format?
+- Dillon has done a great job of passing info to the co-chairs, with extensive
+  notes!!
+- Should papers be submitted at the same time as the abstracts to provide more
+  time for the reviewers?
+- Maybe requests that's submitters review at least one paper?
+
+Diversity
+---------
+
+- This committee needs two people.
+- The committee needs more support and direction from the organizing side to
+  list things that need to happen, when, and where.
+- Julie H was very helpful.
+- They got to do everything they wanted.
+- Maybe have two Diversity lunches? or do it in a larger room? (It'll likely be
+  in the ballroom next year). Some people didn't manage to attend, even if
+  there were no-shows.
+
+
+Bird of a Feathers (BoFs)
+-------------------------
+
+- Highlights that BoFs are *for two-way communication*. It is not
+  a presentation. They're community events.
+- Maybe define what a BoF *is not*?
+- The committee created a Gmail account that can be passed to the next
+  organizers. (Great idea!)
+- BoFs needs a description of what it is everywhere they are mentioned
+  (website, program, etc.). Many people don't know what they are.
+- Should we have two-part BoFs, maybe with something on the weekend (during
+  Sprints), or on Tuesday afternoon?
+- Feedback for the intro at the beginning there every day, before the Keynote.
+  The way the BoFs were announced made them sound as less important than they
+  are. A suggestion for the wording was something along the lines of: "There is
+  a one-hour break for lunch, then there are BoFs, and then there's the plenary
+  session." Instead of saying "There's a two hour lunch break", which means
+  that some people assuming the BoFs are second-class citizens.
+
+

--- a/yearly-notes/2019/bof-for-scipy-2020.rst
+++ b/yearly-notes/2019/bof-for-scipy-2020.rst
@@ -1,0 +1,104 @@
+Notes from the SciPy 2020 BoF
+=============================
+
+Notes from the Birds of a Feather session on Friday, July 12, 2019, to gather
+ideas for SciPy 2020.
+
+Grow or not?
+------------
+
+- We love this space. It's a great venue.
+- It's easier to see people over and over again throughout the week because the
+  conference is not too big.
+- Maybe have multiple ticket types? For example academics, students, single
+  tickets, corporate, etc., with different constraints or numbers. Grace Hopper
+  conference does this.
+- Have more tracks?
+- Try to guess which talks will be large so they're in a larger room.
+- Try streaming popular talks into overflow rooms.
+- There's no desire to cap the size of the conference.
+- The hotel was sold out for many nights
+- If the conference grows, we will need an other way to move posters, and
+  increase engagement with them.
+
+Grab Bag
+--------
+
+- Give a different name to volunteers? Fellows? "Would you serve as a committee
+  member"? "Would you lead..."? To increase the number of people who join the
+  committees.
+- The five minutes time between talk work for some people but didn't for
+  others.
+- Ask people if they want to submit their contact information to a registry to
+  facilitate contacting people who had you have interactions with (this is
+  actually provided by Slack)
+- People loved the program and the paper schedule. Could we add a one line
+  description to the schedule, in addition to titles? Would it fit?
+- Could we make the schedule horizontally as a single thing, instead of over
+  two pages?
+- Assert that the WiFi will work for attendees with their particular technical
+  requirements
+- Could talks be shorter? 15 to 20 minutes? Maybe not, that would require
+  cutting a lot of "how the sausage is made." If we do, how would we use the
+  extra time? More talks, or do something else?
+- Slight larger restrooms
+
+
+Diversity
+---------
+
+- Increase the size of the Diversity luncheon.
+- The impromptu second diverse city luncheon was great.
+
+Poster Sessions
+---------------
+
+- Many people would like posters to have a more important presence.
+- Maybe do odd/even, or split them up. We need something to make posters
+  a first class citizen.
+- Could we do the poster session during catered lunch? We should be careful
+  that it doesn't overlap with the diversity luncheon.
+
+Sponsors
+--------
+
+- Sponsored tables are not in a great location to have impromptu interactions.
+  Maybe move them downstairs along the flow of people between the ballroom and
+  the smaller rooms?
+
+Birds of a feather (BoF)
+------------------------
+
+- We might have lost something by pre-organizing all the birds of feather
+  sessions. Maybe bring back Impromptu boss and advertise that rooms are
+  available for them.
+
+
+Submission process
+------------------
+
+- Maybe make more obviously the people have submitted a talk for a poster in
+  the confirmation email. A presenter taught their proposal was accepted as
+  a talk but only realized a few weeks before the conference that it was
+  actually a poster.
+
+Tutorials
+---------
+
+- There are concerns about some fundamental tutorials not having been excepted
+  given that some more pointed tutorials were.
+- Some people suggest giving more power to the tutorials committee to select
+  tutorials. Some other people worry that it would give the tutorial committee
+  too much power.
+- maybe creative intermediate track?
+- increase outreach for underrepresented communities to teach tutorials. Review
+  who has talked at PyLadies, PyCon, PyData, and ask them to submit tutorials.
+- could we increase the number of tutorials even more? 
+- Be more explicit about the possibility of full-day tutorials.
+- Backspace encourage trial applicants period
+
+Lightning talks
+---------------
+
+- Space get an HDMI switcher or two podiums so one presenter can get ready
+  while the other one is presenting.

--- a/yearly-notes/2019/index.rst
+++ b/yearly-notes/2019/index.rst
@@ -1,0 +1,7 @@
+Notes from SciPy 2019
+=====================
+
+.. toctree::
+
+  2019-post-con-lunch
+  bof-for-scipy-2020

--- a/yearly-notes/index.rst
+++ b/yearly-notes/index.rst
@@ -1,0 +1,11 @@
+Yearly Notes
+============
+
+Notes collected during each SciPy Conference
+
+
+.. toctree::
+  :maxdepth: 2
+
+  2019/index
+  2018/index


### PR DESCRIPTION
Adds notes from the 2018 and 2019 post-con lunches, and from the planning BoF for SciPy 2020, at the end of SciPy 2019.