### PR TITLE
Add pre-commit-hooks by PC100 in Scientific Python

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,18 @@ repos:
         (?x)^(
             .*\.csv
         )$
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.5.0
+  hooks:
+  - id: check-added-large-files
+  - id: check-case-conflict
+  - id: check-merge-conflict
+  - id: check-symlinks
+  - id: check-yaml
+  - id: debug-statements
+  - id: end-of-file-fixer
+  - id: mixed-line-ending
+  - id: name-tests-test
+    args: ["--pytest-test-first"]
+  - id: requirements-txt-fixer
+  - id: trailing-whitespace


### PR DESCRIPTION
See https://learn.scientific-python.org/development/guides/style/#pre-commit .