### PR TITLE
Add internationalization configurations to conf.py

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -42,6 +42,10 @@ source_suffix = ".rst"
 # The master toctree document.
 master_doc = "index"
 
+# Sphinx document translation with sphinx gettext feature uses these settings:
+locale_dirs = ["locale/"]
+gettext_compact = False
+
 # General information about the project.
 project = "SciPy Conference"
 copyright = "2014-2024, SciPy Conference Organizers"


### PR DESCRIPTION
### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
- ref [Internationalization](https://www.sphinx-doc.org/en/master/usage/advanced/intl.html#quick-guide)
- By adding this, documents can be internationalized by placing a [locale](https://github.com/tkoyama010/scipy-conference-translations/tree/main/locale) directory in root.
- Relate to https://github.com/tkoyama010/scipy-conference-translations/pull/11.