### PR TITLE
chore: Update conference link for 2025

### DIFF
--- a/manual/program/reviewer_guidelines.rst
+++ b/manual/program/reviewer_guidelines.rst
@@ -20,7 +20,7 @@ Instructions
   :width: 400
   :alt: One does not simply Pretalx
 
-Go to https://cfp.scipy.org/orga/event/2024/reviews/ to see your assigned proposals.
+Go to https://cfp.scipy.org/orga/event/scipy2025/reviews/ to see your assigned proposals.
 Each proposal will ask you to provide the following:
 
 - **"Overall Evaluation"** (score +2 to -2)

--- a/manual/program/track_chair_instructions.rst
+++ b/manual/program/track_chair_instructions.rst
@@ -10,7 +10,7 @@ SciPy Track Chair responsibilities
   :width: 400
   :alt: With great power comes great responsibility
 
-The role of the track co-chairs is to help shape the program for SciPy 2024. This includes:
+The role of the track co-chairs is to help shape the program for SciPy. This includes:
 
 - encouraging submissions from your community
 


### PR DESCRIPTION
* The conference Pretalx organiser link for 2024 and 2025 differ significanlty in name which can lead to people thinking a page permenantly 404s when they're just at the wrong URL.
* Remove year of conference as the track chair information is reusable.